### PR TITLE
[WL7-209]매장상세정보 바텀시트 스타일 변경 및 리액트 타입 설치

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@storybook/test": "^9.0.0-alpha.2",
         "@types/node": "^24.0.10",
         "@types/qs": "^6.14.0",
+        "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.5.2",
         "@vitest/browser": "^3.2.4",
@@ -2982,7 +2983,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@storybook/test": "^9.0.0-alpha.2",
     "@types/node": "^24.0.10",
     "@types/qs": "^6.14.0",
+    "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
     "@vitest/browser": "^3.2.4",

--- a/src/components/common/CallButton.tsx
+++ b/src/components/common/CallButton.tsx
@@ -4,7 +4,13 @@ type CallButtonProps = {
 };
 
 const CallButton: React.FC<CallButtonProps> = ({ onClick, width }) => {
-  const buttonWidthClass = typeof width === 'number' ? `w-[${width}px]` : (width ?? 'w-[146px]');
+  // 명시적으로 지원할 width 클래스만 정적 분기
+  let buttonWidthClass = 'w-[146px]';
+
+  if (width === 169) buttonWidthClass = 'w-[169px]';
+  else if (width === 180) buttonWidthClass = 'w-[180px]';
+  else if (typeof width === 'string') buttonWidthClass = width;
+
   return (
     <button
       className={`group ${buttonWidthClass} h-[46px] relative bg-white hover:bg-green-50 transition-colors duration-200 rounded-lg flex-shrink-0`}

--- a/src/components/common/LocationButton.tsx
+++ b/src/components/common/LocationButton.tsx
@@ -9,7 +9,13 @@ type LocationButtonProps = {
  * 마우스 호버 시 배경색이 pink-50으로 변경되고 아이콘 및 텍스트 색상이 더 진한 핑크색으로 바뀝니다.
  */
 const LocationButton: React.FC<LocationButtonProps> = ({ onClick, width }) => {
-  const buttonWidthClass = typeof width === 'number' ? `w-[${width}px]` : (width ?? 'w-[146px]');
+  // Tailwind에서 정적으로 인식 가능한 width 클래스만 분기 처리
+  let buttonWidthClass = 'w-[146px]';
+
+  if (width === 169) buttonWidthClass = 'w-[169px]';
+  else if (width === 180) buttonWidthClass = 'w-[180px]';
+  else if (typeof width === 'string') buttonWidthClass = width;
+
   return (
     <button
       className={`group ${buttonWidthClass} h-[46px] relative flex items-center justify-center bg-white 

--- a/src/components/map/BottomSheetLocationDetail.tsx
+++ b/src/components/map/BottomSheetLocationDetail.tsx
@@ -93,7 +93,7 @@ const BottomSheetLocationDetail: React.FC<BottomSheetLocationDetailProps> = ({
         </div>
 
         <div className="mt-1">
-          <h3 className="font-semibold text-lm text-black">{store.name}</h3>
+          <h3 className="font-semibold text-lg text-black">{store.name}</h3>
         </div>
 
         <div className="mt-1">

--- a/src/components/map/BottomSheetLocationDetail.tsx
+++ b/src/components/map/BottomSheetLocationDetail.tsx
@@ -56,14 +56,20 @@ const BottomSheetLocationDetail: React.FC<BottomSheetLocationDetailProps> = ({
 
   const handleBookmarkToggle = async () => {
     const prev = isBookmarked;
-    setIsBookmarked(!prev); // 💡 낙관적 UI 처리
+    const next = !prev;
+    setIsBookmarked(next); // 낙관적 UI
 
     try {
       await toggleFavorite(store.placeId);
+
+      // 즐겨찾기 ON 상태에서 해제했다면 목록 갱신 요청
+      if (prev === true && next === false && localStorage.getItem('isBookmarkOnly') === 'true') {
+        window.dispatchEvent(new Event('refreshMapStores'));
+      }
     } catch (err) {
       console.error('즐겨찾기 변경 실패:', err);
       alert('즐겨찾기 변경에 실패했습니다.');
-      setIsBookmarked(prev); // 실패 시 롤백
+      setIsBookmarked(prev);
     }
   };
 

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -8,6 +8,7 @@ import { getPlaces } from '@/apis/getPlaces';
 export interface MapContainerRef {
   showCurrentLocation: () => void;
   setCenter: (lat: number, lng: number) => void;
+  fetchPlaces: () => void;
 }
 
 interface MapContainerProps {
@@ -83,6 +84,9 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(
           const newCenter = new window.kakao.maps.LatLng(lat, lng);
           map.setCenter(newCenter);
         }
+      },
+      fetchPlaces: () => {
+        fetchPlacesInViewportRef.current();
       },
     }));
 

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -76,6 +76,18 @@ const MapPage = () => {
     }
   }, [benefitCategories]);
 
+  useEffect(() => {
+    const handleRefreshStores = () => {
+      console.log('🔄 [refreshMapStores] 이벤트 수신됨 - 지도 재요청');
+      mapRef.current?.fetchPlaces();
+    };
+
+    window.addEventListener('refreshMapStores', handleRefreshStores);
+    return () => {
+      window.removeEventListener('refreshMapStores', handleRefreshStores);
+    };
+  }, []);
+
   const handleCurrentLocation = () => {
     mapRef.current?.showCurrentLocation();
   };


### PR DESCRIPTION
## 📝 변경 사항(커밋 단위)

1. 위치/전화 버튼을 props로 너비를 전달할 경우 조건문으로 처리되게끔 하였습니다.
2. 즐겨찾기 필터링이 인식되어 있는 상황에서 매장 상세정보에서 매장의 즐겨찾기를 해제하면 마커가 다시 랜더링 되도록 구현하였습니다.
3. 매장 상세정보의 title 스타일을 변경하였습니다.
4. 리액트 타입을 설치하였습니다.

## 🔍 변경 사항 세부 설명

1-1.

## 📷 스크린샷 (선택)

## 🕵️‍♀️ 요청사항 (선택)
