### PR TITLE
[WL7-209] 바텀시트 공통컴포넌트 오류 수정 및 클러스터링 클릭 이벤트 적용

### DIFF
--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion, useMotionValue } from 'framer-motion';
 
 interface BottomSheetProps {
   isOpen: boolean;
@@ -9,6 +9,17 @@ interface BottomSheetProps {
 }
 
 const BottomSheet = ({ isOpen, onClose, children, disablePadding }: BottomSheetProps) => {
+  const y = useMotionValue(0);
+
+  const handleDrag = (
+    _: MouseEvent | TouchEvent | PointerEvent,
+    info: { offset: { y: number } }
+  ) => {
+    if (info.offset.y < 0) {
+      y.set(0);
+    }
+  };
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -29,7 +40,9 @@ const BottomSheet = ({ isOpen, onClose, children, disablePadding }: BottomSheetP
               drag="y"
               dragConstraints={{ top: 0, bottom: 0 }}
               dragMomentum={false}
-              dragElastic={0.1}
+              dragElastic={0.2}
+              style={{ y }}
+              onDrag={handleDrag}
               onDragEnd={(_, info) => {
                 if (info.offset.y > 100) {
                   onClose();

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -28,6 +28,8 @@ const BottomSheet = ({ isOpen, onClose, children, disablePadding }: BottomSheetP
               transition={{ type: 'spring', stiffness: 300, damping: 30 }}
               drag="y"
               dragConstraints={{ top: 0, bottom: 0 }}
+              dragMomentum={false}
+              dragElastic={0.1}
               onDragEnd={(_, info) => {
                 if (info.offset.y > 100) {
                   onClose();

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -36,7 +36,11 @@ const BottomSheet = ({ isOpen, onClose, children, disablePadding }: BottomSheetP
               initial={{ y: '100%' }}
               animate={{ y: 0 }}
               exit={{ y: '100%' }}
-              transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+              transition={{
+                type: 'tween',
+                duration: 0.4,
+                ease: [0.25, 0.46, 0.45, 0.94],
+              }}
               drag="y"
               dragConstraints={{ top: 0, bottom: 0 }}
               dragMomentum={false}

--- a/src/components/map/BottomSheetCoupon.tsx
+++ b/src/components/map/BottomSheetCoupon.tsx
@@ -323,9 +323,11 @@ const BottomSheetCoupon = ({ isOpen, onClose, mapRef, onMarkerClick }: BottomShe
                           }}
                           onLocationClick={(lat, lng) => {
                             if (!mapRef.current) return;
+
+                            mapRef.current.setSelectedMarker(Number(store.placeId));
+
                             mapRef.current.setCenter(lat, lng);
                             mapRef.current.setLevel(1);
-                            mapRef.current.setSelectedMarker(Number(store.placeId));
                             onClose();
                             onMarkerClick(Number(store.placeId), String(lat), String(lng));
                           }}

--- a/src/components/map/BottomSheetCoupon.tsx
+++ b/src/components/map/BottomSheetCoupon.tsx
@@ -324,6 +324,7 @@ const BottomSheetCoupon = ({ isOpen, onClose, mapRef, onMarkerClick }: BottomShe
                           onLocationClick={(lat, lng) => {
                             if (!mapRef.current) return;
                             mapRef.current.setCenter(lat, lng);
+                            mapRef.current.setLevel(1);
                             mapRef.current.setSelectedMarker(Number(store.placeId));
                             onClose();
                             onMarkerClick(Number(store.placeId), String(lat), String(lng));

--- a/src/components/map/BottomSheetLocationDetail.tsx
+++ b/src/components/map/BottomSheetLocationDetail.tsx
@@ -126,6 +126,7 @@ const BottomSheetLocationDetail: React.FC<BottomSheetLocationDetailProps> = ({
 
     if (isDifferent) {
       mapRef.current?.setCenter(targetLat, targetLng);
+      mapRef.current?.setLevel(1);
     }
   };
 
@@ -135,7 +136,7 @@ const BottomSheetLocationDetail: React.FC<BottomSheetLocationDetailProps> = ({
 
   return (
     <BottomSheet isOpen={isOpen} onClose={onClose} disablePadding>
-      <div className="relative w-full bg-white rounded-t-[20px] p-[19px] pb-5 flex flex-col">
+      <div className="relative w-full bg-white rounded-t-[20px] p-[19px] pb-1 flex flex-col">
         {store.eventTypeCode !== 'NONE' && (
           <div className="text-pink-600 font-bold text-sm mb-1">이벤트 매장</div>
         )}

--- a/src/components/map/EventAreaCircle.tsx
+++ b/src/components/map/EventAreaCircle.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import type { KakaoMap, KakaoCircle } from '@/types/kakao';
+
+interface EventAreaCircleProps {
+  center: { lat: number; lng: number };
+  radius: number;
+  map: KakaoMap;
+}
+
+const EventAreaCircle = ({ center, radius, map }: EventAreaCircleProps) => {
+  const circleRef = useRef<KakaoCircle | null>(null);
+
+  useEffect(() => {
+    if (!map || !window.kakao?.maps) return;
+
+    // 메인 원 (3D 효과를 위한 다중 레이어)
+    const mainCircle = new window.kakao.maps.Circle({
+      center: new window.kakao.maps.LatLng(center.lat, center.lng),
+      radius: radius,
+      strokeWeight: 5,
+      strokeColor: '#FF6B9D',
+      strokeOpacity: 0.8,
+      strokeStyle: 'solid',
+      fillColor: '#FF1493',
+      fillOpacity: 0.15,
+    });
+
+    // 원들을 지도에 추가
+    mainCircle.setMap(map);
+
+    // 참조 저장
+    circleRef.current = mainCircle;
+
+    // 클린업 함수
+    return () => {
+      if (mainCircle) mainCircle.setMap(null);
+    };
+  }, [map, center.lat, center.lng, radius]);
+
+  return null;
+};
+
+export default EventAreaCircle;

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -14,6 +14,7 @@ import type {
 import CurrentLocationMarker from '@/components/map/CurrentLocationMarker';
 import MapMarkerIcon from '../common/MapMarkerIcon';
 import PlaceNameLabel from './PlaceNameLabel';
+import EventAreaCircle from './EventAreaCircle';
 import { getPlaces } from '@/apis/getPlaces';
 
 export interface MapContainerRef {
@@ -61,7 +62,7 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(
     const currentLocationRef = useRef<{ lat: number; lng: number } | null>(null);
     const [isLocationShown, setIsLocationShown] = useState(false);
     const fetchPlacesInViewportRef = useRef<() => void>(() => {});
-    const staticCircleRef = useRef<KakaoCircle | null>(null);
+    const [mapInstance, setMapInstance] = useState<KakaoMap | null>(null);
     const [selectedPlaceId, setSelectedPlaceId] = useState<number | null>(null);
     const selectedPlaceIdRef = useRef<number | null>(null);
     const isSettingCenterRef = useRef(false);
@@ -661,18 +662,7 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(
               clustererRef.current = null;
             }
 
-            const staticCircle = new window.kakao.maps.Circle({
-              center: new window.kakao.maps.LatLng(37.544581, 127.055961),
-              radius: 800,
-              strokeWeight: 5,
-              strokeColor: '#DFA2A2',
-              strokeOpacity: 1,
-              strokeStyle: 'shortdash',
-              fillColor: '#F316B0',
-              fillOpacity: 0.08,
-            });
-            staticCircle.setMap(map);
-            staticCircleRef.current = staticCircle;
+            setMapInstance(map);
 
             showCurrentLocation();
 
@@ -711,9 +701,6 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(
 
       return () => {
         document.head.removeChild(script);
-        if (staticCircleRef.current) {
-          staticCircleRef.current.setMap(null);
-        }
         if (clustererRef.current && markerInstancesRef.current.length > 0) {
           clustererRef.current.removeMarkers(markerInstancesRef.current);
         }
@@ -736,7 +723,17 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(
       }
     }, [shouldRestoreLocation]);
 
-    return <div ref={mapRef} className="w-full h-full absolute top-0 left-0 z-0" />;
+    return (
+      <div ref={mapRef} className="w-full h-full absolute top-0 left-0 z-0">
+        {mapInstance && (
+          <EventAreaCircle
+            center={{ lat: 37.544581, lng: 127.055961 }}
+            radius={800}
+            map={mapInstance}
+          />
+        )}
+      </div>
+    );
   }
 );
 

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -657,6 +657,21 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(
                 ],
               });
               clustererRef.current = clusterer;
+
+              // 클러스터 클릭 이벤트 리스너 추가
+              window.kakao.maps.event.addListener(
+                clusterer,
+                'clusterclick',
+                (cluster: KakaoMarkerClusterer) => {
+                  const currentLevel = map.getLevel();
+                  const newLevel = Math.max(1, currentLevel - 2);
+
+                  // 클러스터 중심으로 이동
+                  const center = cluster.getCenter();
+                  map.setCenter(center);
+                  map.setLevel(newLevel);
+                }
+              );
             } catch (error) {
               console.error('클러스터러 초기화 실패:', error);
               clustererRef.current = null;

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -469,8 +469,8 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(
           // 마커를 컨테이너에 추가
           containerElement.appendChild(markerElement);
 
-          // 지도 레벨 6 이하에서 장소명 텍스트 추가
-          if (currentLevel <= 6) {
+          // 지도 레벨 4 이하에서 장소명 텍스트 추가
+          if (currentLevel <= 4) {
             const textHTML = ReactDOMServer.renderToString(
               <PlaceNameLabel
                 placeName={place.placeName}

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -370,7 +370,12 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(
       setLevel: (level) => {
         const map = mapInstanceRef.current;
         if (map) {
+          isSettingCenterRef.current = true;
           map.setLevel(level);
+          setTimeout(() => {
+            isSettingCenterRef.current = false;
+            renderMarkers();
+          }, 500);
         }
       },
       fetchPlaces: () => {
@@ -445,7 +450,7 @@ const MapContainer = forwardRef<MapContainerRef, MapContainerProps>(
               category={place.categoryCode}
               storeClass={place.markerCode}
               event={place.eventCode}
-              isSelected={selectedPlaceId === place.placeId}
+              isSelected={selectedPlaceIdRef.current === place.placeId}
             />
           );
 

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -57,6 +57,22 @@ export interface KakaoEvent {
 export interface KakaoCircle {
   setMap(map: KakaoMap | null): void;
   getBounds(): KakaoMapBounds;
+  setRadius(radius: number): void;
+  setOptions(options: {
+    strokeWeight?: number;
+    strokeColor?: string;
+    strokeOpacity?: number;
+    strokeStyle?:
+      | 'solid'
+      | 'shortdash'
+      | 'shortdot'
+      | 'shortdashdot'
+      | 'longdash'
+      | 'longdot'
+      | 'longdashdot';
+    fillColor?: string;
+    fillOpacity?: number;
+  }): void;
 }
 
 export interface KakaoMarkerClusterer {

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -52,6 +52,11 @@ export interface KakaoEvent {
     type: string,
     handler: (event?: { latLng?: KakaoLatLng }) => void
   ): void;
+  addListener(
+    target: KakaoMarkerClusterer,
+    type: 'clusterclick',
+    handler: (cluster: KakaoMarkerClusterer) => void
+  ): void;
 }
 
 export interface KakaoCircle {
@@ -81,6 +86,7 @@ export interface KakaoMarkerClusterer {
   clear(): void;
   getMarkers(): KakaoMarker[];
   setMap(map: KakaoMap | null): void;
+  getCenter(): KakaoLatLng;
 }
 
 declare global {


### PR DESCRIPTION
## 📝 변경 사항(커밋 단위)

1. 공통 바텀시트 컴포넌트의 드래그 오류를 수정하였습니다.
2. 상세정보 바텀시트의 높이를 수정하였습니다.
3. 공통 바텀시트의 컴포넌트 로직을 수정하였습니다.
4. 쿠폰 바텀시트의 위치보기 로직을 수정하였습니다.
5. 공통 바텀시트의 스타일을 수정하였습니다.
6. 줌레벨 4부터 매장명이 표시되도록 변경하였습니다.
7. 이번주니어 동네원을 변경하였습니다.
8. 클러스터링 클릭 이벤트에 따른 줌인 기능을 적용하였습니다.
9. 병합커밋

## 🔍 변경 사항 세부 설명

2-1. 해당 장소에 대한 마커와 장소명이 바텀시트에 가려지지 않도록 조치하였습니다.

## 📷 스크린샷 (선택)

## 🕵️‍♀️ 요청사항 (선택)
